### PR TITLE
Remove call to docker inspect

### DIFF
--- a/src/spec-node/devContainersSpecCLI.ts
+++ b/src/spec-node/devContainersSpecCLI.ts
@@ -507,7 +507,7 @@ async function doBuild({
 		await Promise.all(disposables.map(d => d()));
 	};
 	// Support multiple use of `--image-name`
-	const imageNames = (Array.isArray(argImageName) ? argImageName : [argImageName]) as string[]
+	const imageNames = (Array.isArray(argImageName) ? argImageName : [argImageName]) as string[];
 
 	try {
 		const workspaceFolder = path.resolve(process.cwd(), workspaceFolderArg);

--- a/src/spec-node/singleContainer.ts
+++ b/src/spec-node/singleContainer.ts
@@ -103,7 +103,7 @@ export async function buildNamedImageAndExtend(params: DockerResolverParameters,
 		return await buildAndExtendImage(params, configWithRaw as SubstitutedConfig<DevContainerFromDockerfileConfig>, imageNames, params.buildNoCache ?? false, additionalFeatures);
 	}
 	// image-based dev container - extend
-	return await extendImage(params, configWithRaw, imageNames[0], additionalFeatures, canAddLabelsToContainer);
+	return await extendImage(params, configWithRaw, imageNames[0], additionalFeatures, canAddLabelsToContainer, imageNames);
 }
 
 async function buildAndExtendImage(buildParams: DockerResolverParameters, configWithRaw: SubstitutedConfig<DevContainerFromDockerfileConfig>, baseImageNames: string[], noCache: boolean, additionalFeatures: Record<string, string | boolean | Record<string, string | boolean>>) {


### PR DESCRIPTION
Previously, devcontainer-cli would call docker inspect, fail, and fall back to accessing the registry. This skips the docker inspect and makes it go directly to the registry.